### PR TITLE
🦊 links do not display underline in Firefox

### DIFF
--- a/src/sames/styles.css
+++ b/src/sames/styles.css
@@ -118,7 +118,6 @@ strong {
 	font-weight: 500;
 }
 .link {
-	display: contents;
 	text-decoration: underline;
 }
 mark {


### PR DESCRIPTION
before
![](https://user-images.githubusercontent.com/22254091/71781871-5266c980-2fdc-11ea-9c0d-a4991a2cbc70.png)

after
![](https://user-images.githubusercontent.com/22254091/71781881-66aac680-2fdc-11ea-93bc-7ba68b86e903.png)
